### PR TITLE
Added exclude node_modules to webpack.config's babel-loader.

### DIFF
--- a/tutorial/10-immutable-redux-improvements/webpack.config.babel.js
+++ b/tutorial/10-immutable-redux-improvements/webpack.config.babel.js
@@ -7,6 +7,7 @@ export default {
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
+        exclude: [/node_modules/],
       },
     ],
   },

--- a/tutorial/11-testing-mocha-chai-sinon/webpack.config.babel.js
+++ b/tutorial/11-testing-mocha-chai-sinon/webpack.config.babel.js
@@ -7,6 +7,7 @@ export default {
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
+        exclude: [/node_modules/],
       },
     ],
   },

--- a/tutorial/12-flow/webpack.config.babel.js
+++ b/tutorial/12-flow/webpack.config.babel.js
@@ -7,6 +7,7 @@ export default {
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
+        exclude: [/node_modules/],
       },
     ],
   },

--- a/tutorial/7-client-webpack/webpack.config.babel.js
+++ b/tutorial/7-client-webpack/webpack.config.babel.js
@@ -7,6 +7,7 @@ export default {
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
+        exclude: [/node_modules/],
       },
     ],
   },

--- a/tutorial/8-react/webpack.config.babel.js
+++ b/tutorial/8-react/webpack.config.babel.js
@@ -7,6 +7,7 @@ export default {
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
+        exclude: [/node_modules/],
       },
     ],
   },

--- a/tutorial/9-redux/webpack.config.babel.js
+++ b/tutorial/9-redux/webpack.config.babel.js
@@ -7,6 +7,7 @@ export default {
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
+        exclude: [/node_modules/],
       },
     ],
   },


### PR DESCRIPTION
The webpack update is great. Thank you for it. I want to make one recommendation, but please let me know if I'm misunderstanding, as I'm still learning:

Starting from commit https://github.com/verekia/js-stack-from-scratch/commit/300317b4f821ec9455e4ceebd26b23458b89d817 you introduced ```webpack.config.babel.js``` to manage the bundling and ```babel-loader```. I believe it's common practice to either ```exclude: /node_modules/``` or ```include``` specific files or folders to avoid having babel-loader go through the whole node_modules folder. **I believe this affects chapters 7-12.**

I made the change below and noticed that it decreased the run time of ```gulp``` task ```main``` from 15 seconds to 2.5 seconds when excluding /node_modules/ in chapter 11. The resulting ```client-bundle.js``` is slightly different but seems to work just the same.

The bolded line below shows the change to 6 files (```webpack.config.babel.js``` in chapter 7-12):
<pre>
loaders: [
{
  test: /\.jsx?$/,
  loader: "babel-loader",
  <b>exclude: [/node_modules/],</b>
}
</pre>