### PR TITLE
Fix old reference to npm install in packages section

### DIFF
--- a/tutorial/2-packages/README.md
+++ b/tutorial/2-packages/README.md
@@ -23,7 +23,7 @@ Congratulations, you installed and used a package!
 
 - Run `yarn remove color`
 
-**Note**: There are 2 kinds of package dependencies, `"dependencies"` and `"devDependencies"`. `"dependencies"` is more general than `"devDependencies"`, which are packages that you only need during development, not production (typically, build-related packages, linters, etc). For `"devDependencies"`, we will use `yarn add [package] --dev` in addition to `yarn add [package]`.
+**Note**: There are 2 kinds of package dependencies, `"dependencies"` and `"devDependencies"`. `"dependencies"` is more general than `"devDependencies"`, which are packages that you only need during development, not production (typically, build-related packages, linters, etc). For `"devDependencies"`, we will use `yarn add --dev [package]`.
 
 
 Next section: [3 - Setting up ES6 with Babel and Gulp](/tutorial/3-es6-babel-gulp)

--- a/tutorial/2-packages/README.md
+++ b/tutorial/2-packages/README.md
@@ -23,7 +23,7 @@ Congratulations, you installed and used a package!
 
 - Run `yarn remove color`
 
-**Note**: There are 2 kinds of package dependencies, `"dependencies"` and `"devDependencies"`. `"dependencies"` is more general than `"devDependencies"`, which are packages that you only need during development, not production (typically, build-related packages, linters, etc). For `"devDependencies"`, we will use the `--save-dev` parameter instead of `--save`.
+**Note**: There are 2 kinds of package dependencies, `"dependencies"` and `"devDependencies"`. `"dependencies"` is more general than `"devDependencies"`, which are packages that you only need during development, not production (typically, build-related packages, linters, etc). For `"devDependencies"`, we will use `yarn add [package] --dev` in addition to `yarn add [package]`.
 
 
 Next section: [3 - Setting up ES6 with Babel and Gulp](/tutorial/3-es6-babel-gulp)


### PR DESCRIPTION
The `--save-dev` and `--save` flags were referring to `npm install`. Most will know to look at the yarn docs, but this could be super confusing for newbies.