### PR TITLE
Add instruction to install del package

### DIFF
--- a/tutorial/3-es6-babel-gulp/README.md
+++ b/tutorial/3-es6-babel-gulp/README.md
@@ -5,6 +5,7 @@ We're now going to use ES6 syntax, which is a great improvement over the "old" E
 - Run `yarn add --dev gulp`
 - Run `yarn add --dev gulp-babel`
 - Run `yarn add --dev babel-preset-latest`
+- Run `yarn add --dev del`
 - In `package.json`, add a `babel` field for the babel configuration. Make it use the latest Babel preset like this:
 
 ```json


### PR DESCRIPTION
In gulpfile.js there is a line of code(`const del = require('del');`) to add 'del' package but you never referenced how to add it. For a beginner, this can be frustrating so I added instruction for installing del package.