### PR TITLE
Add command to install del package

### DIFF
--- a/tutorial/3-es6-babel-gulp/README.md
+++ b/tutorial/3-es6-babel-gulp/README.md
@@ -5,6 +5,7 @@ We're now going to use ES6 syntax, which is a great improvement over the "old" E
 - Run `yarn add --dev gulp`
 - Run `yarn add --dev gulp-babel`
 - Run `yarn add --dev babel-preset-latest`
+- Run `yarn add --dev del`
 - In `package.json`, add a `babel` field for the babel configuration. Make it use the latest Babel preset like this:
 
 ```json


### PR DESCRIPTION
I'm going through this tutorial with a fresh install of everything, I didn't seem to have the `del` package.

Here's what I got when I hit the `yarn start` at the bottom:

```bash
tal at Tals-MacBook-Air in ~/Open Source/js-stack-from-scratch on master▲
$ yarn start
yarn start v0.16.1
$ gulp
module.js:474
    throw err;
    ^

Error: Cannot find module 'del'
    at Function.Module._resolveFilename (module.js:472:15)
    at Function.Module._load (module.js:420:25)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/tal/Open Source/js-stack-from-scratch/gulpfile.js:3:13)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
error Command failed with exit code 1.
tal at Tals-MacBook-Air in ~/Open Source/js-stack-from-scratch on master▲
```

Adding `del` fixed it :tada:

```bash
$ yarn add --dev del
yarn add v0.16.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
success Saved 12 new dependencies.
├─ array-union@1.0.2
├─ array-uniq@1.0.3
├─ arrify@1.0.1
├─ del@2.2.2
├─ fs.realpath@1.0.0
├─ glob@7.1.1
├─ globby@5.0.0
├─ is-path-cwd@1.0.0
├─ is-path-in-cwd@1.0.0
├─ is-path-inside@1.0.0
├─ path-is-inside@1.0.2
└─ rimraf@2.5.4
✨  Done in 2.70s.

tal at Tals-MacBook-Air in ~/Open Source/js-stack-from-scratch on master▲
$ yarn start
yarn start v0.16.1
$ gulp
[19:18:36] Using gulpfile ~/Open Source/js-stack-from-scratch/gulpfile.js
[19:18:36] Starting 'watch'...
[19:18:36] Finished 'watch' after 13 ms
[19:18:36] Starting 'clean'...
[19:18:36] Finished 'clean' after 14 ms
[19:18:36] Starting 'build'...
[19:18:36] Finished 'build' after 239 ms
[19:18:36] Starting 'main'...
Hello ES6
```