### PR TITLE
Make `nvm install node` and use the latest version...

### DIFF
--- a/tutorial/1-node-npm-yarn-package-json/README.md
+++ b/tutorial/1-node-npm-yarn-package-json/README.md
@@ -17,7 +17,7 @@ You want any version of Node > 6.5.0.
 
 `npm`, the default package manager for Node, comes automatically with Node, so you don't have to install it yourself.
 
-**Note**: If Node is already installed, install `nvm` ([Node Version Manager](https://github.com/creationix/nvm)), make `nvm` install and use the latest version of Node for you.
+**Note**: If Node is already installed, install `nvm` ([Node Version Manager](https://github.com/creationix/nvm)), make `nvm install node` and use the latest version of Node for you.
 
 [Yarn](https://yarnpkg.com/) is another package manager which is much faster than NPM, has offline support, and fetches dependencies [more predictably](https://yarnpkg.com/en/docs/yarn-lock). Since it [came out](https://code.facebook.com/posts/1840075619545360) in October 2016, it received a very quick adoption and is becoming the new package manager of choice of the JavaScript community. We are going to use Yarn in this tutorial. If you want to stick to NPM you can simply replace all `yarn add` and `yarn add --dev` commands of this tutorial by `npm install --save` and `npm install --dev`.
 


### PR DESCRIPTION
I'm a bit confused by this command:
as specified in the [documentation](https://github.com/creationix/nvm/blob/master/README.markdown#usage) it should be `nvm install node`. 
But may be you mean `nvm install` - if there is such an alias? Sorry, can't check the last for now.