### PR TITLE
Fix dangling-comma linter error

### DIFF
--- a/tutorial/6-eslint/README.md
+++ b/tutorial/6-eslint/README.md
@@ -107,6 +107,45 @@ gulp.task('build', ['lint', 'clean'], () =>
 );
 ```
 
+If you run `yarn start` now, you may see a complaint about dangling commas on our multi-line ES6-style functions. This is because they are being passed as arguments to `gulp.task`, and multi-line arguments should have dangling commas, for example:
+
+```javascript
+foo(
+  argument1,
+  argument2,
+);
+
+// instead of,
+
+foo(
+  argument1,
+  argument2
+)
+
+```
+
+We can fix it by wrapping the body of the function in parenthesis.
+
+```javascript
+gulp.task('lint', () => (
+  gulp.src([
+    paths.allSrcJs,
+    paths.gulpFile,
+  ])
+    .pipe(eslint())
+    .pipe(eslint.format())
+    .pipe(eslint.failAfterError())
+));
+
+// [...]
+
+gulp.task('build', ['lint', 'clean'], () => (
+  gulp.src(paths.allSrcJs)
+    .pipe(babel())
+    .pipe(gulp.dest(paths.libDir))
+));
+```
+
 The last issue left is about `console.log()`. Let's say that we want this `console.log()` to be valid in `index.js` instead of triggering a warning in this example. You might have guessed it, we'll put `/* eslint-disable no-console */` at the top of our `index.js` file.
 
 - Run `yarn start` and we are now all clear again.

--- a/tutorial/6-eslint/gulpfile.babel.js
+++ b/tutorial/6-eslint/gulpfile.babel.js
@@ -12,7 +12,7 @@ const paths = {
   libDir: 'lib',
 };
 
-gulp.task('lint', () =>
+gulp.task('lint', () => (
   gulp.src([
     paths.allSrcJs,
     paths.gulpFile,
@@ -20,15 +20,15 @@ gulp.task('lint', () =>
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError())
-);
+));
 
 gulp.task('clean', () => del(paths.libDir));
 
-gulp.task('build', ['lint', 'clean'], () =>
+gulp.task('build', ['lint', 'clean'], () => (
   gulp.src(paths.allSrcJs)
     .pipe(babel())
     .pipe(gulp.dest(paths.libDir))
-);
+));
 
 gulp.task('main', ['build'], (callback) => {
   exec(`node ${paths.libDir}`, (error, stdout) => {


### PR DESCRIPTION
Note: see https://github.com/verekia/js-stack-from-scratch/issues/90 for more info.

Newer versions of `eslint-config-airbnb` complain about the lack
of dangling-commas on multi-line function calls (e.g. v13). Some of
the gulpfile examples in Chapter 6 were tripping up the linter. To
address this:

- Instruct people following the tutorial to wrap multi-line ES6 style
  functions in parenthesis.
- Update the gulpfile in ch6 to reflect this style change.