### PR TITLE
Add missing eslinter setup instructions

### DIFF
--- a/tutorial/6-eslint/README.md
+++ b/tutorial/6-eslint/README.md
@@ -28,6 +28,7 @@ We'll create a Gulp task that runs ESLint for us. So we'll install the ESLint Gu
 Add the following task to your `gulpfile.babel.js`:
 
 ```javascript
+// [...]
 import eslint from 'gulp-eslint';
 
 const paths = {
@@ -35,8 +36,6 @@ const paths = {
   gulpFile: 'gulpfile.babel.js',
   libDir: 'lib',
 };
-
-// [...]
 
 gulp.task('lint', () => {
   return gulp.src([
@@ -47,6 +46,10 @@ gulp.task('lint', () => {
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());
 });
+
+// [...]
+
+
 ```
 
 Here we tell Gulp that for this task, we want to include `gulpfile.babel.js`, and the JS files located under `src`.
@@ -56,6 +59,17 @@ Modify your `build` Gulp task by making the `lint` task a prerequisite to it, li
 ```javascript
 gulp.task('build', ['lint', 'clean'], () => {
   // ...
+});
+```
+
+Finally, update your watch task to also watch for changes in the Gulpfile:
+
+```javascript
+gulp.task('watch', () => {
+  gulp.watch([
+    paths.allSrcJs,
+    paths.gulpFile
+  ], ['main']);
 });
 ```
 

--- a/tutorial/6-eslint/README.md
+++ b/tutorial/6-eslint/README.md
@@ -83,7 +83,7 @@ One type of issue you will see is `'gulp' should be listed in the project's depe
 
 This way, ESLint won't apply the rule `import/no-extraneous-dependencies` in this file.
 
-Now we are left with the issue `Unexpected block statement surrounding arrow body (arrow-body-style)`. That's a great one. ESLint is telling us that there is a better way to write the following code:
+Second issue we'll address is `Unexpected block statement surrounding arrow body (arrow-body-style)`. That's a great one. ESLint is telling us that there is a better way to write the following code:
 
 ```javascript
 () => {
@@ -121,7 +121,30 @@ gulp.task('build', ['lint', 'clean'], () =>
 );
 ```
 
-The last issue left is about `console.log()`. Let's say that we want this `console.log()` to be valid in `index.js` instead of triggering a warning in this example. You might have guessed it, we'll put `/* eslint-disable no-console */` at the top of our `index.js` file.
+Next issue is `Missing trailing comma (comma-dangle)`. Javascript language allows for trailing commas in array or object declarations, or in arrow functions return statements. You might have noticed that we already added trailing commas in some places. We'll add them in all the remaining places as it's recommended for [better diffs and easier code manipulation](https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8#.j1t5uirvj)
+
+```javascript
+gulp.task('lint', () =>
+  gulp.src([
+    paths.allSrcJs,
+    paths.gulpfile,
+  ])
+  .pipe(eslint())
+  .pipe(eslint.format())
+  .pipe(eslint.failAfterError()),
+);
+
+gulp.task('clean', // [...]
+
+gulp.task('build', ['lint', 'clean'], () =>
+  gulp.src(paths.allSrcJs)
+    .pipe(babel())
+    .pipe(gulp.dest(paths.libDir)),
+);
+```
+
+The last issue left is about `console.log()`. Let's say that we want this `console.log()` to be valid instead of triggering a warning in this example. You might have guessed it, we'll put `/* eslint-disable no-console */` at the top of our `index.js` file. For `gulpfile.babel.js` we can merge the two eslint-disable statements into a single one:
+`/* eslint-disable import/no-extraneous-dependencies, no-console */`
 
 - Run `yarn start` and we are now all clear again.
 

--- a/tutorial/6-eslint/gulpfile.babel.js
+++ b/tutorial/6-eslint/gulpfile.babel.js
@@ -38,7 +38,10 @@ gulp.task('main', ['build'], (callback) => {
 });
 
 gulp.task('watch', () => {
-  gulp.watch(paths.allSrcJs, ['main']);
+  gulp.watch([
+    paths.allSrcJs,
+    paths.gulpfile
+  ], ['main']);
 });
 
 gulp.task('default', ['watch', 'main']);


### PR DESCRIPTION
There's a new rule on the trailing commas for arrow functions with single line implicit return statement. I couldn't find what's the idea behind. I guess it's due to possibility to return objects.

Also, I've added `paths.gruntFile` to `grunt.watch`. (I'd call this variable `gruntfile` since that's how the file is called itself - not `grunt_file.js` or `gruntFile.js`)

PS Should I also update all the following tutorial pages with my changes?
