### PR TITLE
Add install note for Windows users

### DIFF
--- a/tutorial/11-testing-mocha-chai-sinon/README.md
+++ b/tutorial/11-testing-mocha-chai-sinon/README.md
@@ -9,6 +9,7 @@
 We are going to use [Mocha](http://mochajs.org/) as our main testing framework. Mocha is easy to use, has tons of features, and is currently the [most popular JavaScript testing framework](http://stateofjs.com/2016/testing/). It is very flexible and modular. In particular, it lets you use any assertion library you want. [Chai](http://chaijs.com/) is a great assertion library that has a lot of [plugins](http://chaijs.com/plugins/) available and lets you choose between different assertion styles.
 
 - Let's install Mocha and Chai by running `yarn add --dev mocha chai`
+- Note: Windows users will need to add `--ignore-optional` to the end of the command above, as some dependencies require an `fsevents` version that is not available for Windows. This causes the install to fail.
 
 In `state-test.js`, write the following:
 


### PR DESCRIPTION
Windows users need to add an additional argument as the fsevents library that some dependencies require, is not available on Windows.