### PR TITLE
eslint-config-airbnb 14.0.0 now uses eslint-plugin-jsx-a11y v3.

### DIFF
--- a/tutorial/6-eslint/README.md
+++ b/tutorial/6-eslint/README.md
@@ -2,7 +2,7 @@
 
 We're going to lint our code to catch potential issues. ESLint is the linter of choice for ES6 code. Instead of configuring the rules we want for our code ourselves, we will use the config created by Airbnb. This config uses a few plugins, so we need to install those as well to use their config.
 
-- Run `yarn add --dev eslint eslint-config-airbnb eslint-plugin-import eslint-plugin-jsx-a11y@2.2.3 eslint-plugin-react`
+- Run `yarn add --dev eslint eslint-config-airbnb eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-react`
 
 As you can see, you can install several packages in one command. It will add all of these to your `package.json`, as usual.
 


### PR DESCRIPTION
The tutorial currently uses eslint-plugin-jsx-a11y at 2.2.3 due to a previous incompatibility caused by eslint-config-airbnb requiring that specific version. eslint-config-airbnb 14.0.0 is now using the latest version (v3) of eslint-plugin-jsx-a11y and using the old version will cause an error.