### PR TITLE
replaces SheetsRegistryProvider with JssProvider

### DIFF
--- a/tutorial/08-bootstrap-jss.md
+++ b/tutorial/08-bootstrap-jss.md
@@ -373,7 +373,7 @@ export const JSS_SSR_SELECTOR = `.${JSS_SSR_CLASS}`
 - Edit `src/server/render-app.jsx` like so:
 
 ```js
-import { SheetsRegistry, SheetsRegistryProvider } from 'react-jss'
+import { SheetsRegistry, JssProvider } from 'react-jss'
 // [...]
 import { APP_CONTAINER_CLASS, JSS_SSR_CLASS, STATIC_PATH, WDS_PORT } from '../shared/config'
 // [...]
@@ -383,9 +383,9 @@ const renderApp = (location: string, plainPartialState: ?Object, routerContext: 
   const appHtml = ReactDOMServer.renderToString(
     <Provider store={store}>
       <StaticRouter location={location} context={routerContext}>
-        <SheetsRegistryProvider registry={sheets}>
+        <JssProvider registry={sheets}>
           <App />
-        </SheetsRegistryProvider>
+        </JssProvider>
       </StaticRouter>
     </Provider>)
   // [...]


### PR DESCRIPTION
In the latest version of react-jss (2017-06-28) that yarn installs, there are breaking changes:

```
- Removed `createInjectSheet`. Use JssProvider to pass a `jss` instead instead.
- Renamed `SheetsRegistryProvider` to `JssProvider`
```

See `changelog.md` inside `node_modules`. It doesn't show up in the github repo README for some reason. 

Let me know if you want me to submit PR for the JS-Stack-Boilerplate repo. Thanks for all the hard work on this. Learned a lot!

