### PR TITLE
Yarn test fails due to flow error

### DIFF
--- a/tutorial/02-babel-es6-eslint-flow-jest-husky.md
+++ b/tutorial/02-babel-es6-eslint-flow-jest-husky.md
@@ -245,6 +245,9 @@ I know this is a lot to take in, so take a minute to think about it. I'm still a
 ```flowconfig
 [options]
 suppress_comment= \\(.\\|\n\\)*\\flow-disable-next-line
+
+[ignore]
+.*/node_modules/eslint-plugin-jsx-a11y/*
 ```
 
 This is a little utility that we set up to make Flow ignore any warning detected on the next line. You would use it like this, similarly to `eslint-disable`:


### PR DESCRIPTION
EDIT: This should no longer be an issue with the latest version of these packages, but if you have this problem here is the fix.

Going through the guide and I got a flow error running `yarn test` at the part where one is required to add flow. See:
 https://github.com/verekia/js-stack-from-scratch/issues/221

The solution is to add the following to your `.flowconfig` :

```
[ignore]
.*/node_modules/eslint-plugin-jsx-a11y/*
```

I propose to add this to the guide so others won't have this issue. Like these people: https://github.com/verekia/js-stack-from-scratch/issues/237 and https://github.com/verekia/js-stack-from-scratch/issues/221