### PR TITLE
Fix Issue with react-jss

### DIFF
--- a/tutorial/08-bootstrap-jss.md
+++ b/tutorial/08-bootstrap-jss.md
@@ -373,7 +373,7 @@ export const JSS_SSR_SELECTOR = `.${JSS_SSR_CLASS}`
 - Edit `src/server/render-app.jsx` like so:
 
 ```js
-import { SheetsRegistry, SheetsRegistryProvider } from 'react-jss'
+import { SheetsRegistry, JssProvider } from 'react-jss'
 // [...]
 import { APP_CONTAINER_CLASS, JSS_SSR_CLASS, STATIC_PATH, WDS_PORT } from '../shared/config'
 // [...]
@@ -383,9 +383,9 @@ const renderApp = (location: string, plainPartialState: ?Object, routerContext: 
   const appHtml = ReactDOMServer.renderToString(
     <Provider store={store}>
       <StaticRouter location={location} context={routerContext}>
-        <SheetsRegistryProvider registry={sheets}>
+        <JssProvider registry={sheets}>
           <App />
-        </SheetsRegistryProvider>
+        </JssProvider>
       </StaticRouter>
     </Provider>)
   // [...]


### PR DESCRIPTION
Quoting from issue https://github.com/verekia/js-stack-from-scratch/issues/243:

At the end of chapter 08, I've got some errors just after src/server/render-app.jsx edit:

```
Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in.
Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in.
    at invariant (/Users/davidfq/Code/js-stack/node_modules/fbjs/lib/invariant.js:44:15)
    at ReactCompositeComponentWrapper.instantiateReactComponent [as _instantiateReactComponent] (/Users/davidfq/Code/js-stack/node_modules/react-dom/lib/instantiateReactComponent.js:74:56)
...
```

It seems that <SheetsRegistryProvider> is not available in react-jss v7.1.0. I've just changed it <JssProvider> and everything worked.