### PR TITLE
Update immutable to the latest version: 4.0.0-rc.9

### DIFF
--- a/tutorial/05-redux-immutable-fetch.md
+++ b/tutorial/05-redux-immutable-fetch.md
@@ -44,7 +44,7 @@ console.log(immutablePerson)
  */
 ```
 
-- Run `yarn add immutable@4.0.0-rc.2`
+- Run `yarn add immutable@4.0.0-rc.9`
 
 ## Redux
 


### PR DESCRIPTION
Getting this flow error on 4.0.0-rc.2, the error is gone in the latest version, see https://github.com/facebook/immutable-js/issues/1379
```
$ yarn lint && flow && jest --coverage
$ eslint src webpack.config.babel.js --ext .js,.jsx
Error: node_modules/immutable/dist/immutable.js.flow:519
519:   static of<T>(...values: T[]): SetSeq<T>;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. This type is incompatible with
383:   static of<T>(...values: T[]): IndexedSeq<T>;
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type
  This parameter is incompatible:
    519:   static of<T>(...values: T[]): SetSeq<T>;
                                         ^^^^^^^^^ SetSeq. This type is incompatible with
    383:   static of<T>(...values: T[]): IndexedSeq<T>;
                                         ^^^^^^^^^^^^^ IndexedSeq


Found 1 error
```